### PR TITLE
Remove multi-sort and set default ordering

### DIFF
--- a/src/components/data-table/DataTable.tsx
+++ b/src/components/data-table/DataTable.tsx
@@ -35,7 +35,7 @@ type Props<TData, TValue> = {
 export const DataTable = <TData, TValue>(props: Props<TData, TValue>) => {
   const navigate = useNavigate()
   const [local] = splitProps(props, ["columns", "data"])
-  const [sorting, setSorting] = createSignal<SortingState>([])
+  const [sorting, setSorting] = createSignal<SortingState>([{ id: "amount", desc: true }])
   const [columnFilters, setColumnFilters] = createSignal<ColumnFiltersState>([])
   const [columnVisibility, setColumnVisibility] = createSignal<VisibilityState>({})
 
@@ -61,6 +61,7 @@ export const DataTable = <TData, TValue>(props: Props<TData, TValue>) => {
         }
       },
     },
+    enableMultiSort: false,
     onSortingChange: setSorting,
     onColumnFiltersChange: setColumnFilters,
     onColumnVisibilityChange: setColumnVisibility,


### PR DESCRIPTION
Removed multi-sort on columns from the main listings page. Set a default ordering for the main page by VALUE in desc order.